### PR TITLE
Add accordion sidebar to Django admin

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -63,7 +63,7 @@ ROOT_URLCONF = 'app.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates'],
+        'DIRS': [BASE_DIR / 'templates', BASE_DIR / 'app' / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/app/templates/admin/base_site.html
+++ b/app/templates/admin/base_site.html
@@ -1,0 +1,21 @@
+{% extends "admin/base.html" %}
+{% load i18n static %}
+{% block nav-sidebar %}{% include "admin/partials/custom_sidebar.html" %}{% endblock %}
+{% block extrastyle %}{{ block.super }}<style>
+.cc-accordion summary{cursor:pointer;padding:8px 12px;font-weight:600;border-radius:4px;background:#2c3e50;color:#fff;margin:8px 0 4px}
+.cc-accordion .cc-section{margin:6px 0 10px 10px;padding-left:8px;border-left:3px solid #d9e1f2}
+.cc-accordion a.cc-link{display:block;padding:6px 10px;text-decoration:none}
+</style>{% endblock %}
+{% block extrahead %}{{ block.super }}<script>
+document.addEventListener('DOMContentLoaded',function(){
+  document.querySelectorAll('[data-cc-acc-key]').forEach(function(el){
+    const key='cc-acc-'+el.getAttribute('data-cc-acc-key');
+    const state=localStorage.getItem(key);
+    if(state==='open'){el.setAttribute('open','');}
+    el.addEventListener('toggle',function(){
+      if(el.open){localStorage.setItem(key,'open');}
+      else{localStorage.removeItem(key);}
+    });
+  });
+});
+</script>{% endblock %}

--- a/app/templates/admin/partials/custom_sidebar.html
+++ b/app/templates/admin/partials/custom_sidebar.html
@@ -1,0 +1,66 @@
+{% load i18n %}
+<div class="cc-accordion">
+  {% if available_apps %}
+    <!-- Threads管理 -->
+    <details data-cc-acc-key="threads">
+      <summary>Threads管理</summary>
+      <div class="cc-section">
+        {% for app in available_apps %}
+          {% if app.app_label == "th" %}
+            {% for model in app.models %}
+              <a class="cc-link" href="{{ model.admin_url }}">{{ model.name }}</a>
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </details>
+
+    <!-- SNS管理（既存のSNS系アプリ群をまとめて表示） -->
+    <details data-cc-acc-key="sns">
+      <summary>SNS管理</summary>
+      <div class="cc-section">
+        {% for app in available_apps %}
+          {% if app.app_label == "sns_core" or
+                app.app_label == "social_core" or
+                app.app_label == "social" or
+                app.app_label == "webhooks" or
+                app.app_label == "social_webhooks" or
+                app.app_label == "social_scheduler" %}
+            {% for model in app.models %}
+              <a class="cc-link" href="{{ model.admin_url }}">{{ model.name }}</a>
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </details>
+
+    <!-- モール管理（中カテゴリのプレースホルダ） -->
+    <details data-cc-acc-key="mall">
+      <summary>モール管理</summary>
+      <div class="cc-section">
+        <!-- モール関連アプリのリンクをここに追加 -->
+      </div>
+    </details>
+
+    {% for app in available_apps %}
+      {% if app.app_label != "th" and
+            app.app_label != "sns_core" and
+            app.app_label != "social_core" and
+            app.app_label != "social" and
+            app.app_label != "webhooks" and
+            app.app_label != "social_webhooks" and
+            app.app_label != "social_scheduler" %}
+        <details data-cc-acc-key="{{ app.app_label }}">
+          <summary>{{ app.name }}</summary>
+          <div class="cc-section">
+            {% for model in app.models %}
+              {% if model.admin_url %}
+                <a class="cc-link" href="{{ model.admin_url }}">{{ model.name }}</a>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </details>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- include `app/templates` in Django settings
- customize admin base template with accordion sidebar
- persist sidebar section state using localStorage
- group social apps under new "SNS管理" sidebar section

## Testing
- `USE_SQLITE=1 python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c7d63260833183f61ec1c40e9461