### PR TITLE
Add accordion-based AdminLTE sidebar

### DIFF
--- a/app/templates/adminlte/lib/_main_sidebar.html
+++ b/app/templates/adminlte/lib/_main_sidebar.html
@@ -1,0 +1,66 @@
+{% load i18n static admin_urls admin_list %}
+{% get_app_list request as app_list %}
+
+<aside class="main-sidebar sidebar-dark-primary elevation-4">
+  <a href="{% url 'admin:index' %}" class="brand-link">
+    <span class="brand-text font-weight-light">{% trans 'バイヤーズ 管理画面' %}</span>
+  </a>
+  <div class="sidebar">
+    <nav class="mt-2">
+      <style>
+        .cc-accordion summary{cursor:pointer;padding:8px 12px;font-weight:600;border-radius:4px;background:#2c3e50;color:#fff;margin:8px 0 4px}
+        .cc-accordion .cc-section{margin:6px 0 10px 10px;padding-left:8px;border-left:3px solid #d9e1f2}
+        .cc-accordion a.cc-link{display:block;padding:6px 10px;text-decoration:none}
+      </style>
+      <div class="cc-accordion">
+        <!-- インスタグラム管理 -->
+        <details data-cc-acc-key="ig" open>
+          <summary>インスタグラム管理</summary>
+          <div class="cc-section">
+            {% for app in app_list %}{% if app.app_label == "ig" %}
+              {% for model in app.models %}<a class="cc-link" href="{{ model.admin_url }}">{{ model.name }}</a>{% endfor %}
+            {% endif %}{% endfor %}
+          </div>
+        </details>
+        <!-- Threads管理 -->
+        <details data-cc-acc-key="th" open>
+          <summary>Threads管理</summary>
+          <div class="cc-section">
+            {% for app in app_list %}{% if app.app_label == "th" %}
+              {% for model in app.models %}<a class="cc-link" href="{{ model.admin_url }}">{{ model.name }}</a>{% endfor %}
+            {% endif %}{% endfor %}
+          </div>
+        </details>
+        <!-- SNS管理 -->
+        <details data-cc-acc-key="sns">
+          <summary>SNS管理</summary>
+          <div class="cc-section">
+            {% for app in app_list %}
+              {% if app.app_label in "sns_core social social_core webhooks social_webhooks social_scheduler".split %}
+                {% for model in app.models %}<a class="cc-link" href="{{ model.admin_url }}">{{ model.name }}</a>{% endfor %}
+              {% endif %}
+            {% endfor %}
+          </div>
+        </details>
+        <!-- モール管理（プレースホルダ） -->
+        <details data-cc-acc-key="mall">
+          <summary>モール管理</summary>
+          <div class="cc-section">
+            <a class="cc-link" href="/admin/#mall-yahoo">yahoo管理</a>
+            <a class="cc-link" href="/admin/#mall-goo10">goo10管理</a>
+            <a class="cc-link" href="/admin/#mall-aupay">au payモール管理</a>
+          </div>
+        </details>
+        <!-- アカウント管理 -->
+        <details data-cc-acc-key="accounts">
+          <summary>アカウント管理</summary>
+          <div class="cc-section">
+            {% for app in app_list %}{% if app.app_label == "auth" %}
+              {% for model in app.models %}<a class="cc-link" href="{{ model.admin_url }}">{{ model.name }}</a>{% endfor %}
+            {% endif %}{% endfor %}
+          </div>
+        </details>
+      </div>
+    </nav>
+  </div>
+</aside>


### PR DESCRIPTION
## Summary
- customize AdminLTE sidebar with accordion menu
- expose Instagram, Threads, SNS, Mall, and Account sections

## Testing
- `python -m pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'gspread')*

------
https://chatgpt.com/codex/tasks/task_e_68c6e19c4d0083319b0dbba2e6032840